### PR TITLE
Add Google Benchmark support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+option(FASTFILTERS2_BENCHMARK "Build benchmarks")
+
 include(FetchContent)
 FetchContent_Declare(
     highway
@@ -19,12 +21,24 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/pybind/pybind11
     GIT_TAG v2.10.1
     GIT_SHALLOW ON)
+FetchContent_Declare(
+    benchmark
+    GIT_REPOSITORY https://github.com/google/benchmark
+    GIT_TAG v1.7.1
+    GIT_SHALLOW ON)
 
-option(BUILD_TESTING OFF)
-option(HWY_ENABLE_CONTRIB OFF)
-option(HWY_ENABLE_EXAMPLES OFF)
-option(HWY_ENABLE_INSTALL OFF)
-FetchContent_MakeAvailable(highway pybind11)
+set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "")
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "")
+set(BUILD_TESTING OFF CACHE BOOL "")
+set(HWY_ENABLE_CONTRIB OFF CACHE BOOL "")
+set(HWY_ENABLE_EXAMPLES OFF CACHE BOOL "")
+set(HWY_ENABLE_INSTALL OFF CACHE BOOL "")
+
+set(FASTFILTERS2_DEPENDENCIES highway pybind11)
+if(${FASTFILTERS2_BENCHMARK})
+    list(APPEND FASTFILTERS2_DEPENDENCIES benchmark)
+endif()
+FetchContent_MakeAvailable(${FASTFILTERS2_DEPENDENCIES})
 
 add_library(fastfilters2 cpp/fastfilters2.cpp)
 target_link_libraries(fastfilters2 PRIVATE hwy)
@@ -33,3 +47,15 @@ target_include_directories(fastfilters2 PUBLIC cpp)
 pybind11_add_module(_core cpp/_core.cpp)
 target_link_libraries(_core PRIVATE fastfilters2)
 install(TARGETS _core DESTINATION fastfilters2)
+
+add_executable(bm cpp/benchmark.cpp)
+target_link_libraries(bm PRIVATE fastfilters2 benchmark::benchmark)
+add_custom_target(
+    runbm
+    "$<TARGET_FILE:bm>"
+    DEPENDS bm
+    WORKING_DIRECTORY ${bm_BINARY_DIR}
+    VERBATIM
+    USES_TERMINAL
+    COMMAND_EXPAND_LISTS
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,14 +48,16 @@ pybind11_add_module(_core cpp/_core.cpp)
 target_link_libraries(_core PRIVATE fastfilters2)
 install(TARGETS _core DESTINATION fastfilters2)
 
-add_executable(bm cpp/benchmark.cpp)
-target_link_libraries(bm PRIVATE fastfilters2 benchmark::benchmark)
-add_custom_target(
-    runbm
-    "$<TARGET_FILE:bm>"
-    DEPENDS bm
-    WORKING_DIRECTORY ${bm_BINARY_DIR}
-    VERBATIM
-    USES_TERMINAL
-    COMMAND_EXPAND_LISTS
-)
+if(FASTFILTERS2_BENCHMARK)
+    add_executable(bm cpp/benchmark.cpp)
+    target_link_libraries(bm PRIVATE fastfilters2 benchmark::benchmark)
+    add_custom_target(
+        runbm
+        "$<TARGET_FILE:bm>"
+        DEPENDS bm
+        WORKING_DIRECTORY ${bm_BINARY_DIR}
+        VERBATIM
+        USES_TERMINAL
+        COMMAND_EXPAND_LISTS
+    )
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,12 +5,20 @@
             "name": "dev",
             "generator": "Ninja",
             "binaryDir": "build",
-            "installDir": "src"
+            "installDir": "src",
+            "cacheVariables": {
+                "FASTFILTERS2_BENCHMARK": "ON"
+            }
         }
     ],
     "buildPresets": [
         {
-            "name": "dev",
+            "name": "dev.bm",
+            "configurePreset": "dev",
+            "targets": ["runbm"]
+        },
+        {
+            "name": "dev.install",
             "configurePreset": "dev",
             "targets": ["install"]
         }

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ pip install --editable .
 # Configure CMake build.
 cmake --preset dev
 
-# Build: this needs to be run when C++ source files change.
-cmake --build --preset dev
+# Build and run benchmarks: this needs to be run when C++ source files change.
+cmake --build --preset dev.bm
+
+# Build and install Python module: this needs to be run when C++ source files change.
+cmake --build --preset dev.install
 ```
 
 [mambaforge]: https://github.com/conda-forge/miniforge#mambaforge

--- a/cpp/benchmark.cpp
+++ b/cpp/benchmark.cpp
@@ -1,0 +1,31 @@
+#include <benchmark/benchmark.h>
+#include <fastfilters2.h>
+
+#include <random>
+
+namespace ff2 = fastfilters2;
+
+void bm_filters(benchmark::State &state) {
+  std::random_device random_device;
+  std::default_random_engine random_engine(random_device());
+  std::uniform_int_distribution<> dist(0, 255);
+
+  ff2::int_t size[] = {512, 512};
+  constexpr ff2::int_t ndim = 2;
+
+  std::vector<ff2::val_t> vdst(7 * size[0] * size[1]);
+  std::vector<ff2::val_t> vsrc(size[0] * size[1]);
+
+  auto dst = vdst.data();
+  auto src = vsrc.data();
+  ff2::val_t scale = 10;
+
+  for (auto _ : state) {
+    ff2::compute_filters(dst, src, size, ndim, scale);
+    benchmark::DoNotOptimize(dst);
+  }
+}
+
+BENCHMARK(bm_filters)->Unit(benchmark::kMillisecond);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Add an option to build and run benchmarks using the Google Benchmark library.

Also, replace `option(... OFF)` with `set(... OFF CACHE BOOL "")`: the previous configuration was misleading because it created cache variables with `OFF` as a docstring.