### PR TITLE
Run build action only on PR to main or tag push

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{cpp,h}]
+[*.{cpp,h,yaml,yml}]
 indent_size = 2

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,6 +1,12 @@
-name: Build and upload to PyPI
+name: Build/upload to PyPI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    tags:
+      - v*
 
 jobs:
   build_wheels:


### PR DESCRIPTION
Running builds on every push and pull request wastes unnecessary compute, therefore run the build only for PRs to main, and when a new version tag is pushed.

Also, remove "and" from workflow name because uploads happen only on tag pushes.